### PR TITLE
Implement roadmaps route

### DIFF
--- a/__tests__/integration/roadmaps.test.js
+++ b/__tests__/integration/roadmaps.test.js
@@ -46,3 +46,12 @@ describe('Making a GET request on /roadmaps', function() {
     expect(response.body).to.deep.equal(output);
   })
 })
+
+describe('Making a GET request on /roadmaps/1', function () {
+  it('returns a roadmap whose id is 1', async function() {
+    const response = await chai.request(app).get('/roadmaps/1');
+
+    expect(response.status).to.be.equal(200);
+    expect(response.body).to.deep.equal(output[0]);
+  })
+})

--- a/__tests__/integration/roadmaps.test.js
+++ b/__tests__/integration/roadmaps.test.js
@@ -1,0 +1,48 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const app = require('../../src/app');
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+const output = [
+  {
+    "id": 1,
+    "title": "Desenvolvimento Full Stack",
+    "createdAt": "2022-11-02T15:00:30.000Z",
+    "updatedAt": "2022-11-02T16:00:30.000Z"
+  },
+  {
+    "id": 2,
+    "title": "UX/UI Design",
+    "createdAt": "2022-11-02T15:00:30.000Z",
+    "updatedAt": "2022-11-02T16:00:30.000Z"
+  },
+  {
+    "id": 3,
+    "title": "Quality Assurance",
+    "createdAt": "2022-11-02T15:00:30.000Z",
+    "updatedAt": "2022-11-02T16:00:30.000Z"
+  },
+  {
+    "id": 4,
+    "title": "O início",
+    "createdAt": "2022-11-02T15:00:30.000Z",
+    "updatedAt": "2022-11-02T16:00:30.000Z"
+  },
+  {
+    "id": 5,
+    "title": "Opcional",
+    "createdAt": "2022-11-02T15:00:30.000Z",
+    "updatedAt": "2022-11-02T16:00:30.000Z"
+  }
+]
+
+describe('Making a GET request on /roadmaps', function() {
+  it('returns a list of all roadmaps', async function() {
+    const response = await chai.request(app).get('/roadmaps');
+
+    expect(response.status).to.be.equal(200);
+    expect(response.body).to.deep.equal(output);
+  })
+})

--- a/__tests__/integration/users.test.js
+++ b/__tests__/integration/users.test.js
@@ -54,7 +54,7 @@ describe('Making a GET request on /users', function () {
 });
 
 describe('Making a GET request on /users/1', function () {
-  it('returns the user with id equal to 1', async function () {
+  it('returns the user whose id is 1', async function () {
     const response = await chai.request(app).get('/users/1');
 
     expect(response.status).to.be.equal(200);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     # na notação porta_de_fora:porta_de_dentro
     ports:
       # Expõe a porta padrão da aplicação:
-      - 3000:3000
+      - 3001:3001
     # Configura as variáveis de ambiente dentro do container
     environment:
       MYSQL_HOST: db # Nome do service logo abaixo

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "prestart": "npx sequelize-cli db:create && npx sequelize-cli db:migrate && npx sequelize db:seed:all",
+    "prestart": "npx sequelize db:drop && npx sequelize-cli db:create && npx sequelize-cli db:migrate && npx sequelize db:seed:all",
     "start": "node .",
     "test": "mocha __tests__/**/*.test.js --exit",
     "dev": "nodemon .",

--- a/src/app.js
+++ b/src/app.js
@@ -4,7 +4,7 @@ const morgan = require('morgan');
 //const cors = require('cors');
 
 const { authController, globalErrorHandler } = require('./controllers');
-const { userRouter } = require('./routes');
+const { userRouter, roadmapRouter } = require('./routes');
 
 const app = express();
 
@@ -18,8 +18,8 @@ if (process.env.NODE_ENV === 'development') {
 app.use(express.json());
 
 app.use('/login', authController.login);
-
 app.use('/users', userRouter);
+app.use('/roadmaps', roadmapRouter);
 
 app.use(globalErrorHandler);
 

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,9 +1,11 @@
 const authController = require('./authController');
 const globalErrorHandler = require('./errorController');
 const userController = require('./userController');
+const roadmapController = require('./roadmapController');
 
 module.exports = {
   authController,
   globalErrorHandler,
   userController,
+  roadmapController,
 };

--- a/src/controllers/roadmapController.js
+++ b/src/controllers/roadmapController.js
@@ -1,0 +1,6 @@
+const { roadmapService } = require('../services');
+
+exports.getAll = async (_req, res) => {
+  const result = await roadmapService.getAll();
+  res.status(200).json(result);
+};

--- a/src/controllers/roadmapController.js
+++ b/src/controllers/roadmapController.js
@@ -4,3 +4,9 @@ exports.getAll = async (_req, res) => {
   const result = await roadmapService.getAll();
   res.status(200).json(result);
 };
+
+exports.getOne = async (req, res) => {
+  const { id } = req.params;
+  const result = await roadmapService.getOne(id);
+  res.status(200).json(result);
+};

--- a/src/models/contentauthor.js
+++ b/src/models/contentauthor.js
@@ -16,7 +16,6 @@ module.exports = (sequelize, DataTypes) => {
     {
       tableName: 'content_authors',
       timestamps: true,
-      underscored: true,
     }
   );
 

--- a/src/models/courses.js
+++ b/src/models/courses.js
@@ -11,7 +11,6 @@ module.exports = (sequelize, DataTypes) => {
       nameCourse: {
         allowNull: false,
         type: DataTypes.STRING,
-        field: 'name_course',
       },
       type: {
         type: DataTypes.INTEGER,
@@ -51,7 +50,6 @@ module.exports = (sequelize, DataTypes) => {
     {
       tableName: 'courses',
       timestamps: true,
-      underscored: true,
     }
   );
 

--- a/src/models/coursestatus.js
+++ b/src/models/coursestatus.js
@@ -13,7 +13,6 @@ module.exports = (sequelize, DataTypes) => {
     {
       tableName: 'courses_status',
       timestamps: true,
-      underscored: true,
     }
   );
 

--- a/src/models/coursetype.js
+++ b/src/models/coursetype.js
@@ -13,7 +13,6 @@ module.exports = (sequelize, DataTypes) => {
     {
       tableName: 'course_types',
       timestamps: true,
-      underscored: true,
     }
   );
 

--- a/src/models/roadmap.js
+++ b/src/models/roadmap.js
@@ -13,7 +13,6 @@ module.exports = (sequelize, DataTypes) => {
     {
       tableName: 'roadmaps',
       timestamps: true,
-      underscored: true,
     }
   );
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -29,7 +29,6 @@ module.exports = (sequelize, DataTypes) => {
     {
       tableName: 'users',
       timestamps: true,
-      // underscored: true,
     }
   );
 

--- a/src/models/usercoursestatus.js
+++ b/src/models/usercoursestatus.js
@@ -6,7 +6,6 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         primaryKey: true,
         allowNull: false,
-        field: 'id_user',
         references: {
           model: 'users',
           key: 'id',
@@ -26,7 +25,6 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         primaryKey: true,
         allowNull: false,
-        field: 'id_status',
         references: {
           model: 'courses_status',
           key: 'id',
@@ -34,13 +32,11 @@ module.exports = (sequelize, DataTypes) => {
       },
       favoriteCourse: {
         type: DataTypes.BOOLEAN,
-        field: 'favorite_course',
       },
     },
     {
       tableName: 'users_courses_status',
       timestamps: true,
-      underscored: true,
     }
   );
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,7 @@
 const userRouter = require('./userRouter');
+const roadmapRouter = require('./roadmapRouter');
 
 module.exports = {
   userRouter,
+  roadmapRouter
 };

--- a/src/routes/roadmapRouter.js
+++ b/src/routes/roadmapRouter.js
@@ -1,0 +1,6 @@
+const router = require('express').Router();
+const { roadmapController } = require('../controllers');
+
+router.route('/').get(roadmapController.getAll);
+
+module.exports = router;

--- a/src/routes/roadmapRouter.js
+++ b/src/routes/roadmapRouter.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
 const { roadmapController } = require('../controllers');
 
+router.route('/:id').get(roadmapController.getOne);
 router.route('/').get(roadmapController.getAll);
 
 module.exports = router;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,5 +1,7 @@
 const userService = require('./userService');
+const roadmapService = require('./roadmapService');
 
 module.exports = {
   userService,
+  roadmapService,
 };

--- a/src/services/roadmapService.js
+++ b/src/services/roadmapService.js
@@ -1,3 +1,5 @@
 const { Roadmaps } = require('../models');
 
 exports.getAll = async () => Roadmaps.findAll();
+
+exports.getOne = async (id) => Roadmaps.findOne({ where: { id } });

--- a/src/services/roadmapService.js
+++ b/src/services/roadmapService.js
@@ -1,0 +1,3 @@
+const { Roadmaps } = require('../models');
+
+exports.getAll = async () => Roadmaps.findAll();


### PR DESCRIPTION
- Implementa "/roadmaps" e "/roadmaps/:id" usando a arquitetura MSC;
- Implementa testes de integração dessas rotas usando "chai" e "chaiHttp";
- Adiciona novo comando (npx sequelize db:drop) ao script "prestart";
- Altera a chave "ports" do docker-compose de "3000" para "3001";
- Remove a opção "underscored" dos "models" para evitar incompatibilidade entre nomes de colunas.